### PR TITLE
Refactor docker build to use the official nginx image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,157 +1,62 @@
-FROM alpine:3.7
+FROM nginx:1.15.8-alpine as base
 
-LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+FROM base as builder
 
-ARG NGINX_VERSION=1.14.0
-ARG MODULE_PATH=/usr/lib/nginx/modules
 ARG JWT_MODULE_PATH=/usr/local/lib/ngx-http-auth-jwt-module
+ARG LIBJWT_VERSION=1.9.0
 
 RUN mkdir -p $JWT_MODULE_PATH/src
 
 ADD config $JWT_MODULE_PATH/config
 ADD src $JWT_MODULE_PATH/src
 
-RUN  JWT_AUTH_MODULE=ngx_http_auth_jwt_module \
-  && JANSSON_VERSION=2.10 \
-  && LIBJWT_VERSION=1.9.0 \
-  && GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
-  && CONFIG="\
-  --prefix=/etc/nginx \
-  --sbin-path=/usr/sbin/nginx \
-  --modules-path=$MODULE_PATH \
-  --conf-path=/etc/nginx/nginx.conf \
-  --error-log-path=/var/log/nginx/error.log \
-  --http-log-path=/var/log/nginx/access.log \
-  --pid-path=/var/run/nginx.pid \
-  --lock-path=/var/run/nginx.lock \
-  --http-client-body-temp-path=/var/cache/nginx/client_temp \
-  --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-  --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-  --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-  --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-  --user=nginx \
-  --group=nginx \
-  --with-http_ssl_module \
-  --with-http_realip_module \
-  --with-http_gunzip_module \
-  --with-http_auth_request_module \
-  --with-http_gzip_static_module \
-  --with-http_stub_status_module \
-  --with-http_v2_module \
-  --with-http_sub_module \
-  --with-ipv6 \
-  --with-threads \
-  --with-file-aio \
-  --add-dynamic-module=$JWT_MODULE_PATH \
-  --with-http_stub_status_module \
-  "\
-  && addgroup -S nginx \
-  && adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
-  \
-  # Extra runtime depency for libjwt
-  && apk add --no-cache jansson-dev \
-  && apk add --no-cache --virtual .build-deps \
-    gcc \
-    libc-dev \
-    make \
-    openssl-dev \
-    pcre-dev \
-    zlib-dev \
-    linux-headers \
-    curl \
-    gnupg \
-    libxslt-dev \
-    gd-dev \
-  \
-#    geoip-dev \
-  \
-  # Extra build depencies for libjwt
-    autoconf automake libtool cmake check-dev \
-  \
-  # BEGIN libjwt install
-  && mkdir libjwt \
-    && curl -sL https://github.com/benmcollins/libjwt/archive/v$LIBJWT_VERSION.tar.gz \
-     | tar -zx -C libjwt/ --strip-components=1 \
-    && cd libjwt \
-    && autoreconf -i \
-    && ./configure \
-    && make all \
-    && make check \
-    && make install \
-    && cd .. \
-    && rm -rf libjwt \
-  \
-  # END libjwt install
-  && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
-  && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && found=''; \
-  for server in \
-    ha.pool.sks-keyservers.net \
-    hkp://keyserver.ubuntu.com:80 \
-    hkp://p80.pool.sks-keyservers.net:80 \
-    pgp.mit.edu \
-  ; do \
-    echo "Fetching GPG key $GPG_KEYS from $server"; \
-    gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$GPG_KEYS" && found=yes && break; \
-  done; \
-  test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1; \
-  gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
-  && rm -rf "$GNUPGHOME" nginx.tar.gz.asc \
-  && mkdir -p /usr/src \
+RUN apk add --no-cache \
+  # nginx
+  gcc \
+  libc-dev \
+  make \
+  openssl-dev \
+  pcre-dev \
+  zlib-dev \
+  linux-headers \
+  curl \
+  gnupg \
+  libxslt-dev \
+  gd-dev \
+  # libjwt
+  jansson-dev \
+  autoconf \
+  automake \
+  libtool \
+  cmake \
+  check-dev
+
+# BEGIN libjwt install
+RUN mkdir libjwt \
+  && curl -sL https://github.com/benmcollins/libjwt/archive/v$LIBJWT_VERSION.tar.gz \
+   | tar -zx -C libjwt/ --strip-components=1 \
+  && cd libjwt \
+  && autoreconf -i \
+  && ./configure \
+  && make all \
+  && make check \
+  && make install
+
+RUN curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
   && tar -zxC /usr/src -f nginx.tar.gz \
   && rm nginx.tar.gz \
   && cd /usr/src/nginx-$NGINX_VERSION \
-  && ./configure $CONFIG --with-debug \
-  && make -j$(getconf _NPROCESSORS_ONLN) \
-  && mv objs/nginx objs/nginx-debug \
-  && mv objs/$JWT_AUTH_MODULE.so objs/$JWT_AUTH_MODULE-debug.so \
-  && ./configure $CONFIG \
-  && make -j$(getconf _NPROCESSORS_ONLN) \
-  && make install \
-  && rm -rf /etc/nginx/html/ \
-  && mkdir /etc/nginx/conf.d/ \
-  && mkdir -p /usr/share/nginx/html/ \
-  && install -m644 html/index.html /usr/share/nginx/html/ \
-  && install -m644 html/50x.html /usr/share/nginx/html/ \
-  && install -m755 objs/nginx-debug /usr/sbin/nginx-debug \
-  && install -m755 objs/$JWT_AUTH_MODULE-debug.so /usr/lib/nginx/modules/$JWT_AUTH_MODULE-debug.so \
-  && ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
-  && strip /usr/sbin/nginx* \
-  && strip /usr/lib/nginx/modules/*.so \
-  && rm -rf /usr/src/nginx-$NGINX_VERSION \
-  \
-  # Bring in gettext so we can get `envsubst`, then throw
-  # the rest away. To do this, we need to install `gettext`
-  # then move `envsubst` out of the way so `gettext` can
-  # be deleted completely, then move `envsubst` back.
-  && apk add --no-cache --virtual .gettext gettext \
-  && mv /usr/bin/envsubst /tmp/ \
-  \
-  && runDeps="$( \
-    scanelf --needed --nobanner --format '%n#p' /usr/sbin/nginx /usr/lib/nginx/modules/*.so /tmp/envsubst \
-      | tr ',' '\n' \
-      | sort -u \
-      | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-  )" \
-  && apk add --no-cache --virtual .nginx-rundeps $runDeps \
-  && apk del .build-deps \
-  && apk del .gettext \
-  && mv /tmp/envsubst /usr/local/bin/ \
-  \
-  # Remove source
-  && rm -fr /usr/local/lib/ngx-http-auth-jwt-module \
-  \
-  # Remove archives
-  && rm /usr/local/lib/libjwt.a \
-  && rm /usr/lib/libjansson.a \
-  \
-  # forward request and error logs to docker log collector
-  && ln -sf /dev/stdout /var/log/nginx/access.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+  && ./configure --with-compat --add-dynamic-module=$JWT_MODULE_PATH \
+  && make modules
 
-EXPOSE 80
+FROM base
 
-STOPSIGNAL SIGTERM
+ARG LIBJWT=libjwt.so.0.4.0
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY --from=builder /usr/src/nginx-1.15.8/objs/ngx_http_auth_jwt_module.so /usr/lib/nginx/modules/ngx_http_auth_jwt_module.so
+COPY --from=builder /usr/local/lib/${LIBJWT} /lib
+
+RUN apk add --no-cache jansson \
+  && sed -i '1iload_module modules/ngx_http_auth_jwt_module.so;' /etc/nginx/nginx.conf \
+  && ln -s /lib/${LIBJWT} /lib/libjwt.so.0 \
+  && ln -s /lib/${LIBJWT} /lib/libjwt.so


### PR DESCRIPTION
I have refactored the docker build to an multi-stage build based on the official nginx image.
The first "builder stage" uses the nginx version of the official nginx image and compiles the module.
The final stage copies the build artifacts form the build stage onto the official nginx image.

If you are interested in merging this i will also update the test. 

